### PR TITLE
Use JSON API 20240205

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -4,7 +4,7 @@
   <parent>
     <groupId>org.jenkins-ci.plugins</groupId>
     <artifactId>plugin</artifactId>
-    <version>4.77</version>
+    <version>4.78</version>
     <relativePath />
   </parent>
   <groupId>io.jenkins.plugins</groupId>

--- a/pom.xml
+++ b/pom.xml
@@ -19,7 +19,7 @@
       <url>https://opensource.org/license/mit-0/</url>
     </license>
   </licenses>
-  <scm child.scm.connection.inherit.append.path="false" child.scm.developerConnection.inherit.append.path="false" child.scm.url.inherit.append.path="false">
+  <scm>
     <connection>scm:git:https://github.com/${gitHubRepo}</connection>
     <developerConnection>scm:git:https://github.com/${gitHubRepo}</developerConnection>
     <tag>${scmTag}</tag>

--- a/pom.xml
+++ b/pom.xml
@@ -26,7 +26,7 @@
     <url>https://github.com/${gitHubRepo}</url>
   </scm>
   <properties>
-    <revision>20231013</revision>
+    <revision>20240205</revision>
     <changelist>999999-SNAPSHOT</changelist>
     <jenkins.version>2.401.3</jenkins.version>
     <gitHubRepo>jenkinsci/${project.artifactId}-plugin</gitHubRepo>


### PR DESCRIPTION
## Use JSON API 20240205

A changelog does not yet exist, but the differences described in the [tag](https://github.com/stleary/JSON-java/releases/tag/20240205) seem reasonable to me.

The [release history](https://github.com/stleary/JSON-java/blob/master/docs/RELEASES.md) includes the new release but is not a useful changelog.

Additional changes include:

- Simplify scm tag in pom.xml - the long version of the tag is only needed for multi-module repositories.
- Use parent pom 4.78 - most recent release

### Testing done

Ran automated tests with `mvn clean verify`.

```[tasklist]
### Submitter checklist
- [x] Make sure you are opening from a **topic/feature/bugfix branch** (right side) and not your main branch!
- [x] Ensure that the pull request title represents the desired changelog entry
- [x] Please describe what you did
- [x] Link to relevant issues in GitHub or Jira
- [x] Link to relevant pull requests, esp. upstream and downstream changes
- [x] Ensure you have provided tests - that demonstrates feature works or fixes the issue
```
