### PR TITLE
docs: correct spelling of JSON API in plugin title

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -11,7 +11,7 @@
   <artifactId>json-api</artifactId>
   <version>${revision}-${changelist}</version>
   <packaging>hpi</packaging>
-  <name>JSON Api Plugin</name>
+  <name>JSON API Plugin</name>
   <url>https://github.com/jenkinsci/${project.artifactId}-plugin</url>
   <licenses>
     <license>


### PR DESCRIPTION
Resolves #20

Simple documentation fix to correct the spelling/capitalization of the plugin title from "JSON Api" to "JSON API" in the `pom.xml`.

### Testing done

Verified build and tests locally using `mvn clean test`.

### Submitter checklist
- [x] Make sure you are opening from a **topic/feature/bugfix branch** (right side) and not your main branch!
- [x] Ensure that the pull request title represents the desired changelog entry
- [x] Please describe what you did
- [x] Link to relevant issues in GitHub or Jira
- [ ] Link to relevant pull requests, esp. upstream and downstream changes
- [x] Ensure you have provided tests that demonstrate the feature works or the issue is fixed

<!--
Put an `x` into the [ ] to show you have filled the information.
The template comes from https://github.com/jenkinsci/.github/blob/master/.github/pull_request_template.md 
You can override it by creating .github/pull_request_template.md in your own repository 
-->
