### PR TITLE
Adapt build status icon for ci.jenkins.io permissions change

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # Jenkins JSON API Plugin
 
-[![Build Status](https://ci.jenkins.io/job/Plugins/job/json-api-plugin/job/main/badge/icon)](https://ci.jenkins.io/job/Plugins/job/json-api-plugin/job/main/)
+[![Build Status](https://ci.jenkins.io/buildStatus/icon?job=Plugins%2Fjson-api-plugin%2Fmain)](https://ci.jenkins.io/job/Plugins/job/json-api-plugin/job/main/)
 [![Jenkins Plugin](https://img.shields.io/jenkins/plugin/v/json-api.svg)](https://plugins.jenkins.io/json-api)
 [![GitHub release](https://img.shields.io/github/release/jenkinsci/json-api-plugin.svg?label=changelog)](https://github.com/jenkinsci/json-api-plugin/releases/latest)
 [![GitHub license](https://img.shields.io/github/license/jenkinsci/json-api-plugin)](https://github.com/jenkinsci/json-api-plugin/blob/main/LICENSE.md)


### PR DESCRIPTION
## Adapt build status icon for ci.jenkins.io permissions change

Large language models and other readers were causing performance problems.  The ci.jenkins.io controller has been reconfigured to limit access to authenticated users in order to prevent performance problems.  That change requires that we adjust the URL of the embeddable build status update URL.

### Testing done

* Validated the change in a sample repository
* Will check the pull request after it is submitted

### Submitter checklist
- [x] Make sure you are opening from a **topic/feature/bugfix branch** (right side) and not your main branch!
- [x] Ensure that the pull request title represents the desired changelog entry
- [x] Please describe what you did
- [x] Link to relevant issues in GitHub or Jira
- [x] Link to relevant pull requests, esp. upstream and downstream changes
